### PR TITLE
AMPS-431: osgi manifest generation

### DIFF
--- a/maven-amps-plugin/src/it/generateManifestWithNoInstructions/pom.xml
+++ b/maven-amps-plugin/src/it/generateManifestWithNoInstructions/pom.xml
@@ -15,5 +15,13 @@
             </plugin>
         </plugins>
     </build>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.collections</groupId>
+            <artifactId>google-collections</artifactId>
+            <version>1.0</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/maven-amps-plugin/src/it/generateManifestWithNoInstructions/src/main/java/com/atlassian/amps/test/manifest/Test.java
+++ b/maven-amps-plugin/src/it/generateManifestWithNoInstructions/src/main/java/com/atlassian/amps/test/manifest/Test.java
@@ -1,0 +1,9 @@
+package com.atlassian.amps.test.manifest;
+
+import com.google.common.collect.ImmutableList;
+
+public class Test {
+    public void test() {
+        ImmutableList.of("this is a test");
+    }
+}

--- a/maven-amps-plugin/src/it/generateManifestWithNoInstructions/validate.groovy
+++ b/maven-amps-plugin/src/it/generateManifestWithNoInstructions/validate.groovy
@@ -1,4 +1,11 @@
+import java.util.jar.Manifest
+
 assert mavenExitCode == 0, "The maven build should not have failed!"
 
-final def manifest = new File("$basedir/target", 'META-INF/MANIFEST.MF')
-assert !manifest.exists(), "There should be no manifest for no instructions and not an Atlassian plugin"
+final def manifestFile = new File("$basedir/target", 'META-INF/MANIFEST.MF')
+assert manifestFile.exists(), "There should be manifest for no instructions and not an Atlassian plugin, see $manifestFile.absolutePath"
+
+final Manifest manifest = manifestFile.withInputStream { InputStream is -> new Manifest(is) }
+
+assert manifest.mainAttributes.getValue('Import-Package').contains('com.google.common.collect;resolution:=optional;version=\"0.0.0\"'), "Should contain generated instructions"
+

--- a/maven-amps-plugin/src/main/java/com/atlassian/maven/plugins/amps/osgi/GenerateManifestMojo.java
+++ b/maven-amps-plugin/src/main/java/com/atlassian/maven/plugins/amps/osgi/GenerateManifestMojo.java
@@ -25,28 +25,7 @@ public class GenerateManifestMojo extends AbstractAmpsMojo
     public void execute() throws MojoExecutionException, MojoFailureException
     {
         final MavenProject project = getMavenContext().getProject();
-        if (!instructions.isEmpty())
-        {
-            getLog().info("Generating a manifest for this plugin");
-
-            if (!instructions.containsKey(Constants.EXPORT_PACKAGE))
-            {
-                instructions.put(Constants.EXPORT_PACKAGE, "");
-            }
-
-            File metainfLib = file(project.getBuild().getOutputDirectory(), "META-INF", "lib");
-            if (metainfLib.exists())
-            {
-                StringBuilder sb = new StringBuilder(".");
-                for (File lib : metainfLib.listFiles())
-                {
-                    sb.append(",").append("META-INF/lib/" + lib.getName());
-                }
-                instructions.put(Constants.BUNDLE_CLASSPATH, sb.toString());
-            }
-            getMavenGoals().generateManifest(instructions);
-        }
-        else if  (OsgiHelper.isAtlassianPlugin(project))
+        if  (OsgiHelper.isAtlassianPlugin(project))
         {
             getLog().warn("Atlassian plugin detected as the organisation name includes the string 'Atlassian'.  If " +
                           "this is meant for production, you should add bundle " +
@@ -55,18 +34,47 @@ public class GenerateManifestMojo extends AbstractAmpsMojo
                           "bundle generation configuration can be specified " +
                           "via the <instructions> element in the maven-" + getPluginInformation().getId()+"-plugin configuration.  For example:\n" +
                           "    <configuration>\n" +
-                          "        <Import-Package>\n" +
-                          "            com.atlassian.myplugin*,\n" +
-                          "            com.library.optional.*;resolution:=optional,\n" +
-                          "            *\n" +
-                          "        </Import-Package>\n" +
+                          "        <instructions>\n" +
+                          "            <Import-Package>\n" +
+                          "                com.atlassian.myplugin*,\n" +
+                          "                com.library.optional.*;resolution:=optional,\n" +
+                          "                *\n" +
+                          "            </Import-Package>\n" +
+                          "        </instructions>\n" +
                           "    </configuration>\n\n" +
                           "See the Maven bundle plugin (which is used under the covers) for more info: " +
                           "http://felix.apache.org/site/apache-felix-maven-bundle-plugin-bnd.html#ApacheFelixMavenBundlePlugin%28BND%29-Instructions");
         }
-        else
+        getLog().info("Generating a manifest for this plugin");
+
+        if (!instructions.containsKey(Constants.EXPORT_PACKAGE))
         {
-            getLog().info("No manifest instructions found, skipping manifest generation");
+            instructions.put(Constants.EXPORT_PACKAGE, "");
         }
+        if (!instructions.containsKey(Constants.IMPORT_PACKAGE))
+        {
+            getLog().info("No manifest instructions found, using \n" +
+                          "<configuration>\n" +
+                          "    <instructions>\n" +
+                          "        <Import-Package>\n" +
+                          "            *;resolution:=optional;version=\"0.0.0\"\n" +
+                          "        </Import-Package>\n" +
+                          "    </instructions>\n" +
+                          "</configuration>\n\n" +
+                          "");
+            instructions.put(Constants.IMPORT_PACKAGE, "*;resolution:=optional");
+        }
+
+        File metainfLib = file(project.getBuild().getOutputDirectory(), "META-INF", "lib");
+        if (metainfLib.exists())
+        {
+            StringBuilder sb = new StringBuilder(".");
+            for (File lib : metainfLib.listFiles())
+            {
+                sb.append(",").append("META-INF/lib/" + lib.getName());
+            }
+            instructions.put(Constants.BUNDLE_CLASSPATH, sb.toString());
+        }
+        getMavenGoals().generateManifest(instructions);
     }
 }


### PR DESCRIPTION
AMPS-431: add osgi manifest generation even when the osgi instructions are missing.

This adds osgi manifest generation, optional and with version="0.0.0" - It turns out that you need to fix the version in the instructions element
